### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Build Status](https://secure.travis-ci.org/snusnu/substation.png?branch=master)][travis]
 [![Dependency Status](https://gemnasium.com/snusnu/substation.png)][gemnasium]
 [![Code Climate](https://codeclimate.com/github/snusnu/substation.png)][codeclimate]
+[![Inline docs](http://inch-pages.github.io/github/snusnu/substation.png)](http://inch-pages.github.io/github/snusnu/substation)
 [![Coverage Status](https://coveralls.io/repos/snusnu/substation/badge.png?branch=master)][coveralls]
 
 [gem]: https://rubygems.org/gems/substation


### PR DESCRIPTION
Hi Martin,

this patch adds a docs badge to the README to show off inline-documentation to potential contributors: [![Inline docs](http://inch-pages.github.io/github/snusnu/substation.png)](http://inch-pages.github.io/github/snusnu/substation)

The badge links to [Inch Pages](http://inch-pages.github.io), a project that tries to raise the visibility of inline-docs to encourage aspiring Rubyists to document their code. Your status page is http://inch-pages.github.io/github/snusnu/substation/

Inch Pages is still a young project, but already used by projects like [Guard](https://github.com/guard/guard), [Haml](https://github.com/haml/haml), [Pry](https://github.com/pry/pry), and [ROM](https://github.com/rom-rb/rom).

What do you think?
