### PR TITLE
[WIP] Improve observers

### DIFF
--- a/lib/substation/chain.rb
+++ b/lib/substation/chain.rb
@@ -137,7 +137,7 @@ module Substation
     def call(request)
       reduce(request) { |result, processor|
         begin
-          response = processor.call(result)
+          response = processor.run(result)
           return response unless processor.success?(response)
           processor.result(response)
         rescue => exception

--- a/lib/substation/processor.rb
+++ b/lib/substation/processor.rb
@@ -152,7 +152,7 @@ module Substation
     #
     # @api private
     def notify_observers(response)
-      observers.each { |observer| observer.call(response) }
+      observers.each { |observer| observer.call(name, response) }
       response
     end
 

--- a/lib/substation/processor.rb
+++ b/lib/substation/processor.rb
@@ -62,6 +62,10 @@ module Substation
     attr_reader :observers
     private     :observers
 
+    def run(state)
+      notify_observers(call(state))
+    end
+
     # Test wether chain processing should continue
     #
     # @param [Response] response
@@ -111,7 +115,7 @@ module Substation
     #
     # @api private
     def invoke(state)
-      notify_observers(handler.call(state))
+      handler.call(state)
     end
 
     # Decompose +input+ before processing


### PR DESCRIPTION
* [X] Pass the current processor's `name` to observers
* [X] Pass the `Substation::Response` returned from invoking a processor to observers
* [ ] Fix current specs
* [ ] Add specs for the new behavior